### PR TITLE
Fix template

### DIFF
--- a/WebSite.json
+++ b/WebSite.json
@@ -93,7 +93,7 @@
                     "type": "config",
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/Sites', parameters('webSiteName'))]",
-						 "Microsoft.ApplicationInsights.AzureWebSites"
+                        "Microsoft.ApplicationInsights.AzureWebSites"
                     ],
                     "properties": {
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).InstrumentationKey]"

--- a/WebSite.json
+++ b/WebSite.json
@@ -22,7 +22,7 @@
         },
         "skuName": {
             "type": "string",
-            "defaultValue": "F1",
+            "defaultValue": "B1",
             "allowedValues": [
                 "F1",
                 "D1",
@@ -92,7 +92,8 @@
                     "name": "appsettings",
                     "type": "config",
                     "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('webSiteName'))]"
+                        "[resourceId('Microsoft.Web/Sites', parameters('webSiteName'))]",
+						 "Microsoft.ApplicationInsights.AzureWebSites"
                     ],
                     "properties": {
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).InstrumentationKey]"
@@ -114,7 +115,7 @@
             "apiVersion": "2014-04-01",
             "name": "[parameters('appInsightsName')]",
             "type": "Microsoft.Insights/components",
-            "location": "East US",
+            "location": "[resourceGroup().location]",
             "tags": {
                 "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', parameters('webSiteName'))]": "Resource",
                 "displayName": "AppInsightsComponent"


### PR DESCRIPTION
Hi Tomas,

I found this code while reading your [blog post](https://winterdom.com/2017/08/01/aiarm). Excellent work, thank you! It certainly saved me a great deal of time.
But I found that the template itself is not working, hence I am providing the below fixes. I suggest you to update the blog post as well - in case you find my fixes worthy of a merge, of course. :)

Thanks,
Péter

### Changes:
* Change default App Service Plan size to Basic. The Application Insights Profiler won't work with plan sizes below that.
* Make the Web App settings change dependent upon the presence of the extension. Otherwise the settings change would cause the Web App to restart which would fail the deployment at the extension installation step. More on this here: https://stackoverflow.com/questions/45106303/app-insights-status-monitor-extension-failing-to-deploy-with-arm-template
* Set the Application Insights' location to the location of the resource group.