### PR TITLE
Add ApplicationInsightsAgent_EXTENSION_VERSION configuration setting

### DIFF
--- a/WebSite.json
+++ b/WebSite.json
@@ -96,7 +96,8 @@
                         "Microsoft.ApplicationInsights.AzureWebSites"
                     ],
                     "properties": {
-                        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).InstrumentationKey]"
+                        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).InstrumentationKey]",
+                        "ApplicationInsightsAgent_EXTENSION_VERSION": "~2"
                     }
                 },
                 {


### PR DESCRIPTION
This change enables the Application Insights extension by setting ApplicationInsightsAgent_EXTENSION_VERSION to value ~2. 